### PR TITLE
Added sample messages dropdown feature

### DIFF
--- a/app.py
+++ b/app.py
@@ -95,6 +95,9 @@ st.markdown("""
 </style>
 """, unsafe_allow_html=True)
 
+#Load sample messages
+sample_df = pd.read_csv("sample_data.csv")
+
 # Initialise session state
 if 'classification_history' not in st.session_state:
     st.session_state.classification_history = []
@@ -248,12 +251,16 @@ with col1:
     """, unsafe_allow_html=True)
     
     # Message input
-    user_sms = st.text_area(
-        "Enter SMS message to analyse",
-        height=120,
-        placeholder="Type or paste your SMS message here...",
-        help="Enter the SMS message you want to classify as spam or ham (legitimate)"
-    )
+    selected_message=st.selectbox("Choose a sample message (or type your own below): ",[""]+sample_df["message"].tolist())
+    if selected_message:
+        user_sms=selected_message
+    if not selected_message:
+        user_sms = st.text_area(
+           "Enter SMS message to analyse",
+            height=120,
+            placeholder="Type or paste your SMS message here...",
+            help="Enter the SMS message you want to classify as spam or ham (legitimate)"
+        )
     
     # Analysis controls
     col_a, col_b, col_c = st.columns([1, 1, 2])

--- a/sample_data.csv
+++ b/sample_data.csv
@@ -1,0 +1,7 @@
+label,message
+SPAM,Win a brand new car! Click here to claim your prize.
+SPAM,You have won $5000 cash. Click YES to claim.
+SPAM,WIN a FREE iPhone now! Click here to claim your prize.
+HAM,Hey are we still meeting for lunch today?
+HAM,Don't forget to bring your notebook to class.
+HAM,Your order has been shipped and will arrive tomorrow.


### PR DESCRIPTION
Add Dropdown for Sample Messages in Spamlyser


This PR introduces a dropdown feature in the Spamlyser UI to allow users to quickly select from a set of predefined sample messages for spam/ham classification.

Changes Made:

Added sample_data.csv containing a mix of SPAM and HAM example messages.

Implemented a Streamlit dropdown (selectbox) for selecting a sample message.

Integrated dropdown selection with the classification pipeline, allowing users to test without manual typing.

Ensured backward compatibility — users can still manually input custom messages.

Benefits:

Makes the app more user-friendly for new users.

Speeds up testing and demonstration of the spam classification feature.

Helps contributors reproduce bugs more easily.

Testing Done:

Verified dropdown works with all the models and classifies selected messages correctly.

Manually tested both sample and manual input modes.

Screenshots:


<img width="1511" height="974" alt="Screenshot 2025-08-13 173429" src="https://github.com/user-attachments/assets/31801043-2248-4587-8314-62c54675982f" />


<img width="1916" height="965" alt="image" src="https://github.com/user-attachments/assets/a4db139d-ae8a-47d7-995e-5d9ad72bd5c3" />
