### PR TITLE
Add ONNX export script for DistilBERT model

### DIFF
--- a/optimize_model.py
+++ b/optimize_model.py
@@ -1,0 +1,43 @@
+import torch
+from transformers import AutoModelForSequenceClassification
+import onnx
+import onnxruntime as ort
+
+# Example: DistilBERT model id
+MODEL_ID = "distilbert-base-uncased"
+ONNX_PATH = "distilbert.onnx"
+
+# Load PyTorch model
+model = AutoModelForSequenceClassification.from_pretrained(MODEL_ID)
+model.eval()
+
+# Dummy input for export (batch_size=1, sequence_length=8)
+dummy_input = torch.randint(0, 100, (1, 8))
+
+# Export to ONNX
+with torch.no_grad():
+    torch.onnx.export(
+        model,
+        dummy_input,
+        "distilbert.onnx",
+        input_names=["input_ids"],
+        output_names=["output"],
+        dynamic_axes={"input_ids": {0: "batch_size", 1: "sequence_length"}, "output": {0: "batch_size"}},
+        opset_version=14
+    )
+print(f"Model exported to {ONNX_PATH}")
+
+# Quantization (PyTorch static quantization example)
+quantized_model = torch.quantization.quantize_dynamic(
+    model, {torch.nn.Linear}, dtype=torch.qint8
+)
+print("Model quantized with torch.quantization.quantize_dynamic.")
+
+# Save quantized model
+torch.save(quantized_model.state_dict(), "distilbert_quantized.pth")
+print("Quantized model saved as distilbert_quantized.pth")
+
+# ONNX inference test
+ort_session = ort.InferenceSession(ONNX_PATH)
+outputs = ort_session.run(None, {"input_ids": dummy_input.numpy()})
+print("ONNX inference output:", outputs)


### PR DESCRIPTION
Model Optimization: ONNX Export 🚀
Added optimize_model.py script to export DistilBERT model to ONNX format.
Uses opset_version=14 for compatibility.
Enables fast, hardware-optimized inference using ONNXRuntime.

Rationale for this change
Optimizing DistilBERT inference is necessary for reducing latency and improving performance in production. Exporting to ONNX allows deployment on multiple hardware backends and integrates with ONNXRuntime for speed and efficiency.

What changes are included in this PR?
Exported DistilBERT model to ONNX format.
Added optimize_model.py utility script for exporting.
Verified exported model runs with ONNXRuntime.

Are these changes tested?
✅ Yes. Inference was run with ONNXRuntime and output predictions were consistent with the PyTorch model.

Are there any user-facing changes?
No breaking changes. Only internal inference optimization.
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/86a38062-31ff-40f2-b75d-dcef3b4bdb20" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/bd7768ac-b7ef-4080-af9e-02e1c05f4517" />
