### PR TITLE
Add ONNX export script for DistilBERT model

### DIFF
--- a/optimize_model.py
+++ b/optimize_model.py
@@ -1,0 +1,43 @@
+import torch
+from transformers import AutoModelForSequenceClassification
+import onnx
+import onnxruntime as ort
+
+# Example: DistilBERT model id
+MODEL_ID = "distilbert-base-uncased"
+ONNX_PATH = "distilbert.onnx"
+
+# Load PyTorch model
+model = AutoModelForSequenceClassification.from_pretrained(MODEL_ID)
+model.eval()
+
+# Dummy input for export (batch_size=1, sequence_length=8)
+dummy_input = torch.randint(0, 100, (1, 8))
+
+# Export to ONNX
+with torch.no_grad():
+    torch.onnx.export(
+        model,
+        dummy_input,
+        "distilbert.onnx",
+        input_names=["input_ids"],
+        output_names=["output"],
+        dynamic_axes={"input_ids": {0: "batch_size", 1: "sequence_length"}, "output": {0: "batch_size"}},
+        opset_version=14
+    )
+print(f"Model exported to {ONNX_PATH}")
+
+# Quantization (PyTorch static quantization example)
+quantized_model = torch.quantization.quantize_dynamic(
+    model, {torch.nn.Linear}, dtype=torch.qint8
+)
+print("Model quantized with torch.quantization.quantize_dynamic.")
+
+# Save quantized model
+torch.save(quantized_model.state_dict(), "distilbert_quantized.pth")
+print("Quantized model saved as distilbert_quantized.pth")
+
+# ONNX inference test
+ort_session = ort.InferenceSession(ONNX_PATH)
+outputs = ort_session.run(None, {"input_ids": dummy_input.numpy()})
+print("ONNX inference output:", outputs)


### PR DESCRIPTION
 Rationale for this change
This change enables exporting the DistilBERT model to ONNX format, allowing for optimized inference and compatibility with ONNXRuntime. It improves model deployment efficiency and supports future integration with ONNX-based workflows.

What changes are included in this PR?
Added ONNX export script for DistilBERT model
Script uses torch.onnx.export with appropriate opset version
Output ONNX file can be used for fast inference
Are these changes tested?
Manual testing performed by running the export script and verifying the generated ONNX file loads correctly in ONNXRuntime.

Are there any user-facing changes?
No direct user-facing changes. This PR provides backend support for ONNX model deployment.

